### PR TITLE
Create material design trend showcase

### DIFF
--- a/assets/css/2-variables.css
+++ b/assets/css/2-variables.css
@@ -1,73 +1,65 @@
 /*
- *
- *
  * CSS VARIABLES
- *
- *
  */
 
-
-/* https://www.materialpalette.com/red/lime */
-/* BUILD AS MATERIAL DESIGN , SO COLORS, AND ROBOTO FONTS */ 
-
-
-
 :root {
-  /*
-	--main-bg-color: coral;
-  --main-txt-color: blue;
-  --main-padding: 15px;
-	*/
-	
-	
-	/* BREAK POINTS FOR MEDIA QUERIES */
-	/* CSS Variables Level 1’s var() cannot be used in media queries. */
-	/* VS rem SYSTEM */
-	/*
-	--bp-1: 1024px; 
-	--bp-m: 768px;
-	--bp-s: 568px;
-	--bp-xs: 414px; 
-	*/
-	
-	
-/* 
-	DEFINE VARIABLES FOR COLORS OF MATERIAL DESIGN SCHEME 
-	https://www.materialpalette.com/red/lime
-*/	
-	--dark-primary-color: #D32F2F;
-	--light-primary-color: #FFCDD2;
-	--primary-color: #F44336;
-	--text-icons: #FFFFFF;
-	--accent-color: #CDDC39;
-	--primary-text: #212121;
-	--secondary-text: #757575;
-	--divider-text: #BDBDBD;
-	
+  /* Material 3 inspired color roles */
+  --dark-primary-color: #4f378b;
+  --light-primary-color: #eaddff;
+  --primary-color: #6750a4;
+  --on-primary-color: #ffffff;
+  --primary-container: #eaddff;
+  --on-primary-container: #21005d;
+  --secondary-color: #625b71;
+  --on-secondary-color: #ffffff;
+  --secondary-container: #e8def8;
+  --on-secondary-container: #1d192b;
+  --accent-color: #7d5260;
+  --tertiary-container: #ffd8e4;
+  --on-tertiary-container: #31111d;
+  --surface-color: #fef7ff;
+  --surface-container-low: #f9f1ff;
+  --surface-container: #ffffff;
+  --surface-container-high: #f6edff;
+  --surface-variant: #e7def4;
+  --primary-text: #1c1b1f;
+  --secondary-text: #49454f;
+  --outline-color: #7a7289;
+  --outline-variant: #cac4d0;
+  --shadow-color: 21 26 39;
+  --scrim: rgba(17, 16, 28, 0.45);
 
-	
-	/* 
-	 * VARIABLES - FONT-FAMILY
-	 */ 
-	/* and also font as font main, and font aside, generrla, sepcial, etc font-accent, could be a good name, or font-splash */	
-	--primary-font: 'Roboto'; /* ok , works */
-	--secondary-font: 'Ubuntu'; /* ok , works */
-	
-	/* 
-	 * VARIABLES - FONT-SIZE - !!! y lo del font size como rem .... FOR ACCESSIBILITY !!!
-	 */ 
-	--fs-1: 16px; /* VS rem SYSTEM */
-	--fs-1-5: 24px; /* VS rem SYSTEM */
-	--fs-2: 32px; /* VS rem SYSTEM */
-	
-	/* 
-	 * VARIABLES - SPACING 
-	 */ 
-	--spacing-0-75: 18px; /* VS rem SYSTEM */
-	--spacing-1: 24px; /* VS rem SYSTEM */
-	--spacing-2: 48px; /* VS rem SYSTEM */
-	/* --spacing-2: var(--spacing-1) * 2; */  /* VS rem SYSTEM */
-	--spacing-3: 72px; /* VS rem SYSTEM */
-	--spacing-4: 96px; /* VS rem SYSTEM */
-	
-} /* ROOT */
+  /* Typography */
+  --primary-font: 'Roboto';
+  --secondary-font: 'Ubuntu';
+
+  /* Font sizing */
+  --fs-0-875: 14px;
+  --fs-1: 16px;
+  --fs-1-5: 24px;
+  --fs-2: 32px;
+  --fs-3: 40px;
+
+  /* Spacing scale */
+  --spacing-0-5: 12px;
+  --spacing-0-75: 18px;
+  --spacing-1: 24px;
+  --spacing-1-5: 32px;
+  --spacing-2: 48px;
+  --spacing-3: 72px;
+  --spacing-4: 96px;
+
+  /* Radii */
+  --radius-chip: 999px;
+  --radius-card: 28px;
+  --radius-avatar: 20px;
+
+  /* Elevation tokens */
+  --elevation-0: 0 0 0 rgba(0, 0, 0, 0);
+  --elevation-1: 0 1px 2px rgba(var(--shadow-color) / 0.2), 0 1px 3px 1px rgba(var(--shadow-color) / 0.12);
+  --elevation-2: 0 2px 6px rgba(var(--shadow-color) / 0.18), 0 6px 10px 4px rgba(var(--shadow-color) / 0.14);
+  --elevation-3: 0 10px 20px rgba(var(--shadow-color) / 0.18), 0 6px 6px rgba(var(--shadow-color) / 0.24);
+
+  /* Motion */
+  --transition-base: 220ms cubic-bezier(0.2, 0, 0, 1);
+}

--- a/assets/css/3-typography.css
+++ b/assets/css/3-typography.css
@@ -1,67 +1,25 @@
-/* 
- * TYPOGRAPHY 
+/*
+ * TYPOGRAPHY
  */
 
-/* 
- * GOOGLE FONTS - HACER LO DE DOWNLAOD LAS FONT FILES 
- */
-/* @import url('https://fonts.googleapis.com/css?family=Noto+Sans:400,400i,700,700i'); */
-/* @import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');	 */	
-/* @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap'); */
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Ubuntu:wght@400;700&display=swap');
-	
-/* ALL ROBOTO FAMILY */	
-@import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap');
-
-
-
-/* BUILD HEADERS AND ALL THAT, BUT CHECK 1ST WHAT THE RESET IS ACTUALLY DOING */
-
-
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700&family=Ubuntu:wght@400;500;700&display=swap');
 
 html, body {
-	font-size:1rem; /* browser default */
-	/* color:#000; */ /* browser default */
-	
-	color: var(--primary-text);
-	
-	/* font-family: 'Noto Sans', sans-serif; */
-	/* font-family: 'Roboto', sans-serif; */
-	font-family: var(--primary-font), sans-serif;
-	/* font-family: var(--secondary-font), sans-serif; */ /* PRETTY BROKEN ...  */
-	/* font-family: 'Ubuntu', sans-serif; */ /* PRETTY BROKEN ...  */
-	}
-	
-	
-	/* FIND A MONSPACE FONT, PERHAPS ANY MONO ... */s
+  font-size: 1rem;
+  color: var(--primary-text, #1c1b1f);
+  font-family: var(--primary-font), sans-serif;
+  line-height: 1.6;
+  background-color: var(--surface-color);
+}
 
+a,
+a:visited {
+  color: var(--primary-color);
+  text-decoration: none;
+  font-weight: 500;
+}
 
-
-
-
-
-/* PRE-FORMATTING ============================= */
-a, a:visited {
-	text-decoration:none;
-	color:#000; 
-	font-weight:bold;
-	}
-	a:hover {text-decoration:underline;}
-
-
-
-/* ADD BLOCKQUOTE , ASIN MATERIAL DESIGN STANDARDS ETC */
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+a:hover,
+a:focus {
+  text-decoration: underline;
+}

--- a/assets/css/3-typography_htmleditor.css
+++ b/assets/css/3-typography_htmleditor.css
@@ -1,244 +1,75 @@
-/* 
- * TYPOGRAPHY - HTMLEDITOR 
+/*
+ * TYPOGRAPHY SCALE & UI TEXT
  */
 
+h1,
+.h1 {
+  font-size: clamp(2.5rem, 4vw, 3.25rem);
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  line-height: 1.1;
+  margin: 0 0 var(--spacing-0-5);
+}
 
-/* 
-get that header geerantor de tiwtter,pero tb el de mareiakl deisgfn font ssystem, sicohgelo de ahi 
+h2,
+.h2 {
+  font-size: clamp(2rem, 3.2vw, 2.5rem);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+  margin: 0 0 var(--spacing-0-5);
+}
 
-https://material.io/design/typography/the-type-system.html#type-scale
+h3,
+.h3 {
+  font-size: clamp(1.5rem, 2.8vw, 2rem);
+  font-weight: 600;
+  line-height: 1.3;
+  margin: 0 0 var(--spacing-0-5);
+}
 
-*/
+h4,
+.h4 {
+  font-size: clamp(1.25rem, 2.2vw, 1.5rem);
+  font-weight: 600;
+  line-height: 1.35;
+  margin: 0 0 var(--spacing-0-5);
+}
 
-.m_htmleditor { /* REALMENTE SERIA S_ DE STYLE  */
-	
-} /* m_htmleditor */
+p,
+.section__subtitle {
+  margin: 0 0 var(--spacing-0-5);
+  color: var(--secondary-text, #49454f);
+  font-size: 1rem;
+}
 
+small,
+.caption {
+  font-size: var(--fs-0-875);
+  letter-spacing: 0.02em;
+  color: var(--outline-color);
+}
 
-/*
-https://material.io/design/typography/the-type-system.html#type-scale
-*/
-
-    .m_htmleditor h1 {
-			font-weight: 300; /* LIGHT - BUT NOT REALLY ADDED THROUGH THE CDN !!! I THINK ... */			
-			font-size: 96px;
-			letter-spacing: -1.5px;
-			/* REM ETC */
-			
-			
-			/*  color: var(--dark-primary-color);*/
-			/*
-			margin-top: $spacing;
-       margin-bottom: $spacing;
-			*/
-    }
-						
-    .m_htmleditor h2 { /*tb se usa en legalpages !!! */
-			font-weight: 300; /* LIGHT - BUT NOT REALLY ADDED THROUGH THE CDN !!! I THINK ... */
-			font-size: 60px;
-			letter-spacing: -0.5px;
-
-			/*
-			margin-top: $spacing;
-			margin-bottom: $spacing075;
-			*/
-    }
-						
-
-
-
-    .m_htmleditor h3 {
-        /* margin-top:24px; */
-        /* margin-bottom:12px; */
-				/* margin-bottom:6px; */
-				/* margin-bottom: $spacing05; */
-			
-			
-			font-size: 48px;
-			font-weight: 400;  /* NORMAL, AKA REGULRA, BUT WHY .. JUST CAUSE, FOR THE RESET IS NOT DOOUING IT !!!  */
-			
-			/* so maybe ad dit to the reset, for other situations, makes sense 
-			did, but th happened ... 
-			*/
-       }
-    
-    .m_htmleditor h4 {
-			font-weight: 400;	
-			font-size: 34px;
-			letter-spacing: 0.25px;		
-			/*
-			margin-top:24px;
-			margin-bottom:36px;
-			*/
-			/* margin-bottom: $spacing05; */
-      }
-				
-    .m_htmleditor h5 {
-        /*
-			margin-top:24px;
-        margin-bottom: $spacing025;
-			*/
-			font-size: 24px;
-			font-weight: 400;
-    }
-				
-    .m_htmleditor h6 {
-        /*
-			margin-top:24px;
-        margin-bottom: $spacing025;
-			*/
-			font-weight: 500; /* MEDIUM */
-			font-size: 16px;
-			letter-spacing: 0.5px;		
-			
-     }
-		
-/* que toda oestso sean mixins del materail desig type scale (system) */
-
-
-/*
-
-Subtitle 1
-Subtitle 2
-
-Body 1
-Body 2
-
-Button (uppercase)
-Caption
-Overline (uppercase)
-
-
-*/
-
-
-    .m_htmleditor .aka_button  {
-        /* font-size: 16px; */
-        /*
-			margin-top:24px;
-        margin-bottom: $spacing025;
-			*/
-			font-weight: 500; /* MEDIUM */
-			font-size: 14px;
-			letter-spacing: 1.25px;		
-			/* TEXT TRANSOMR UPPERCASE */
-        }
-
-
-
+strong {
+  font-weight: 600;
+}
 
 button {
-	
-	/* FOR RESET FILE */
-	/* border-radius: 0px; */ /* ALSO DO FOR IOS ETC */
-	/* this cause sglitcthy border color thingee */
-	
-	border: 0;  /* OK - THIS TAKES CARE OF THE BORDER ASPECT & RADIUS */
-	/*outline: 0;*/ /* DOES NOTHING */
+  font-family: var(--primary-font), sans-serif;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  text-transform: none;
+}
 
-	padding: 0; /* OK */
-	/* margin: 0; */ 
-
-	background: none; /* OK, TO DELETE BG COLOR */ 
-	
-	
-	/* default is deisplay inline ((block)), so there is a spaceing */
-	/* display: block; */  /* ok, pero comentado por ahor aY LUEGO GETSINAR DESDE PARENT CON FLEX */
-	
-	
-	
-	
-	/* font reset */
-	
-	font-family: 'Roboto'; 
-	
-	
-	
-	/* HAS BG COLR & BORDER ON FICUS (CLICK) */
-	
-	font-weight: 500; /* MEDIUM - but looks a bit dirty wonky */
-	font-size: 14px;
-	letter-spacing: 1.25px;		
-	text-transform: uppercase;  /* PRECAUTION */
-	
-	
-	
-	height: 36px; /* THE TEXT IS VERTICALLLY VENTERED FOR SOME STRANGE REASON ... ??? */
-	/* border: 1px solid red; */
-} /* button */
-
-
-
-
-button.text-button {
-	color: var(--dark-primary-color);
-	color: var(--accent-color);
-	padding: 0px 12px;
-} /* button */
-
-
-
-button.outlined-button {
-	color: var(--dark-primary-color);
-	color: var(--accent-color);
-	padding: 0px 16px;
-	border-radius: 3px ; /* TEST */
-	border-radius: 6px ; /* TEST */
-	
-	border: 2px solid var(--divider-text);
-} /* button */
-
-
-
-
-button.contained-button-with-icon {
-	/* background-color: var(--dark-primary-color);*/
-	background-color: var(--accent-color);
-	color: var(--text-icons);
-	border-radius: 3px ; /* TEST */
-	border-radius: 6px ; /* TEST */
-} /* button */
-
-button.contained-button {
-	padding: 0px 16px;
-	
-	/* background-color: var(--dark-primary-color);*/
-	background-color: var(--accent-color);
-	color: var(--text-icons);
-	
-	border-radius: 3px ; /* TEST */
-	border-radius: 6px ; /* TEST */
-	
-	
-} /* button */
-
-
-
-
-
-
-		/* DO NOTHING, JUST KEEP THE DEFAUKLT BEHAVIOUR, LESS IS MORE */
-    .m_htmleditor p {
-			/* color: red;  */
-			/*
-			margin-bottom: 12px;
-			// padding-bottom: 12px; // LAST OF TYPE...
-			*/
-			}
-			.m_htmleditor p:last-of-type {
-				/*
-				margin-bottom: 12px;
-				// padding-bottom: 12px; // LAST OF TYPE...
-				*/
-				}
-	
-
-
-
-		/*
-		 * LISTS - coger el truco de EPIC mointhly upadtes trick , ams tobust
-		 */
-
-
-
-
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/assets/css/4-layout.css
+++ b/assets/css/4-layout.css
@@ -1,146 +1,178 @@
-/* CSS Document - MACRO LAYOUT */
+/* CSS Document - Layout */
 
-
-
-	
-/*
- * CODE FOR RESPONSIVE STICKY FOOTER
- * Instructions: class "block" to footer
- */
-html, body {
-	/* height: 100%; */ /* CASI QUE DEBERIA ESTAR EN EL CSS RESET TB, POR SI ACASO, BUT NOT SURE */
-	}
-#page { /* + .stickyParent */
-	/*
-	display: table;
-	height: 100%;
-	width:100%;
-	*//* VIP for responsiveness */
-	}
-.stickyFooter { /* stickyFooter, WAS ".block" */
-	/*
-	display: table-row;
-	height: 1px;
-	*/
-	}
-	
-	
-
-	
+html,
 body {
-	/* background-color:#B0BEC5; */
-	/* CAN BE IN EITHER OR */
-	/*
-	display: flex;
+  min-height: 100%;
+}
+
+#page {
+  display: flex;
   min-height: 100vh;
   flex-direction: column;
-	*/
-}	
-	
-	#page {
-		/* background-color:#B0BEC5; */
-		display: flex;
-		min-height: 100vh;
-		flex-direction: column;
-	}	
-	
-	
-/* CENTERED CONTENT */	
+  background: radial-gradient(circle at 0% 0%, rgba(114, 87, 186, 0.08), transparent 55%),
+              radial-gradient(circle at 100% 15%, rgba(255, 216, 228, 0.18), transparent 45%),
+              var(--surface-color);
+}
+
 .frame {
-	margin: 0 auto; /* HACER ALGO CON FLEX ........... */
-	/* max-width: 1200px; */
-	max-width: 1440px;
-	min-width: 320px;
-	padding: 0px var(--spacing-1);
-	/* padding: 0px var(--spacing-2); */
-	}
-	
-	
-	
-/* 
- * HEADER
- */			
-header { /* MAIN */
-	background-color: var(--primary-color);
-	color: var(--text-icons);
-	padding: var(--spacing-0-75) 0px; 
-	}
-	header .inner {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		}
-		.headerMain {
-			font-weight: bold; /* NOW IS NCE ! TIGHT ! */
-			/* font-size: 24px; */
-			/* font-size: var(--fs-2); */
-			font-size: var(--fs-1-5);
-			font-family: var(--secondary-font), sans-serif;
-		}
-		.headerAside {
-			
-		}
+  margin: 0 auto;
+  max-width: 1200px;
+  min-width: 320px;
+  width: 100%;
+  padding: 0 var(--spacing-2);
+}
 
-	
+header {
+  background: linear-gradient(135deg, rgba(103, 80, 164, 0.92), rgba(140, 103, 217, 0.92));
+  color: var(--on-primary-color);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  box-shadow: var(--elevation-1);
+  backdrop-filter: blur(18px);
+}
 
+header .inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-1);
+  padding: var(--spacing-0-75) 0;
+  position: relative;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-0-5);
+}
+
+.brand__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.2);
+  font-size: 24px;
+}
+
+.headerMain {
+  font-weight: 600;
+  font-size: 1.25rem;
+}
+
+.headerAside {
+  font-size: 0.95rem;
+  opacity: 0.8;
+}
+
+.primary-nav ul {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-0-5);
+  margin: 0;
+  padding: 0;
+}
+
+.primary-nav a {
+  padding: 10px 18px;
+  border-radius: var(--radius-chip);
+  color: var(--on-primary-color);
+  font-weight: 500;
+  transition: background var(--transition-base), color var(--transition-base);
+}
+
+.primary-nav a:hover,
+.primary-nav a:focus {
+  background: rgba(255, 255, 255, 0.16);
+  text-decoration: none;
+}
+
+.primary-nav.is-open {
+  display: flex;
+}
 
 .navicon {
-  
-  
+  display: none;
+  color: var(--on-primary-color);
 }
-.navicon span {font-size: 3em;}
 
-	
+.w_content {
+  flex: 1;
+  padding: var(--spacing-3) 0 var(--spacing-4);
+}
 
-	
-	
+main .frame {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+footer {
+  background: var(--surface-container);
+  color: var(--secondary-text, #49454f);
+  border-top: 1px solid var(--outline-variant);
+  box-shadow: var(--elevation-0);
+}
+
+footer .inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-0-5);
+  padding: var(--spacing-0-75) 0;
+}
+
+.footer-link {
+  font-weight: 600;
+}
+
+@media only screen and (max-width: 960px) {
+  .frame {
+    padding: 0 var(--spacing-1);
+  }
+
+  header .inner {
+    gap: var(--spacing-0-5);
+  }
+
+  .primary-nav {
+    display: none;
+  }
+
+  .primary-nav.is-open {
+    display: flex;
+    position: absolute;
+    right: 0;
+    top: calc(100% + 12px);
+    background: rgba(24, 15, 47, 0.92);
+    padding: 16px;
+    border-radius: 18px;
+    box-shadow: var(--elevation-2);
+    backdrop-filter: blur(16px);
+  }
+
+  .primary-nav.is-open ul {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .primary-nav.is-open a {
+    display: block;
+    width: 100%;
+  }
+
+  .navicon {
+    display: inline-flex;
+  }
+}
+
 @media only screen and (max-width: 568px) {
-	
-	header .inner {
-		flex-direction: column;
-		/* justify-content: flex-start; */ /* a reset test  */
-		align-items: flex-start;
-		gap: 9px; /* HALF OF the padding */ /* REQUIRES POLIFILL !!! */
-		}
-	
-}	/* MEDIA QUERY */  
-	
-	
-/* 
- * CONTENT
- */	
-.w_content { /* PROBABLY RENAME THSI , AS l_at least */ /* WAS w_content - OR RENAME AS MAIN, ETC */
-	flex: 1; /* VIP FOR "STICKY FOOTER - SOLVED BY FLEXBOX" IT OCCUPIES ALL THE AVAILABLE SPACE, WHILE SHOWING TEH HEADER & FOOTER */
-	/* border: 3px solid red;  */
-	padding: 48px 0px; /* TEMP */
-	}	
-	
-	
-/* 
- * FOOTER
- */		
-footer { /* MAIN */
-	background-color: var(--primary-color);
-	color: var(--text-icons);
-	text-align: center;
-	}
-	footer .inner {
-		padding: var(--spacing-0-75) 0px; 
-		display: flex;
-		justify-content: flex-end;		
-		}	
-		
-	
-	
-	
-@media only screen and (max-width: 568px) {
-	
-	footer .inner {
-		justify-content: flex-start;
-		}
-	
-}	/* MEDIA QUERY */  
-	
-	
-
-		
+  footer .inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/assets/css/5-content.css
+++ b/assets/css/5-content.css
@@ -1,5 +1,452 @@
-/* CSS Document - DEMO CONTENT */
-		
-/* 
- * DEMO 
- */	
+/* CSS Document - Demo Content */
+
+.surface {
+  background: var(--surface-container);
+  border-radius: var(--radius-card);
+  padding: clamp(var(--spacing-1), 4vw, var(--spacing-2));
+  box-shadow: var(--elevation-1);
+  position: relative;
+  overflow: hidden;
+}
+
+.surface--primary {
+  background: linear-gradient(145deg, rgba(234, 221, 255, 0.95), rgba(246, 237, 255, 0.9));
+  color: var(--on-primary-container);
+}
+
+.surface--primary p,
+.surface--primary .section__subtitle,
+.surface--primary .hero__guides li {
+  color: rgba(33, 0, 93, 0.82);
+}
+
+.surface--raised {
+  background: var(--surface-container);
+  box-shadow: var(--elevation-1);
+}
+
+.hero {
+  display: grid;
+  gap: var(--spacing-1);
+  background-image: radial-gradient(circle at 10% 20%, rgba(103, 80, 164, 0.4), transparent 55%),
+                    radial-gradient(circle at 80% 0%, rgba(255, 216, 228, 0.45), transparent 60%);
+}
+
+.hero__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-weight: 600;
+  padding: 8px 16px;
+  border-radius: var(--radius-chip);
+  background: rgba(103, 80, 164, 0.12);
+  color: var(--on-primary-container);
+  width: fit-content;
+}
+
+.hero__lead {
+  font-size: 1.1rem;
+  max-width: 50ch;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-0-5);
+}
+
+.hero__guides {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-weight: 500;
+}
+
+.hero__guides li {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.hero__guides .material-icons {
+  font-size: 20px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.section__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-1);
+}
+
+.section__subtitle {
+  max-width: 58ch;
+}
+
+.card-grid {
+  display: grid;
+  gap: var(--spacing-1);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.md-card {
+  background: var(--surface-container);
+  border-radius: var(--radius-card);
+  box-shadow: var(--elevation-1);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-0-5);
+  padding: var(--spacing-1);
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.md-card:hover,
+.md-card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: var(--elevation-2);
+}
+
+.md-card__header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: var(--spacing-0-5);
+}
+
+.md-card__avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: #fff;
+  letter-spacing: 0.04em;
+}
+
+.avatar--sunrise {
+  background: linear-gradient(135deg, #ff6f91, #ff9671);
+}
+
+.avatar--lagoon {
+  background: linear-gradient(135deg, #00c9a7, #6c63ff);
+}
+
+.avatar--dusk {
+  background: linear-gradient(135deg, #7b4397, #dc2430);
+}
+
+.avatar--citrus {
+  background: linear-gradient(135deg, #f8b500, #fceabb);
+  color: #31111d;
+}
+
+.md-card__titles h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.md-card__subtitle {
+  margin: 4px 0 0;
+  color: var(--secondary-text);
+  font-size: 0.95rem;
+}
+
+.md-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.md-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.md-list li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+  align-items: start;
+  color: var(--secondary-text);
+}
+
+.md-list .material-icons {
+  font-size: 20px;
+  color: var(--primary-color);
+}
+
+.md-card__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-0-5);
+}
+
+/* Buttons */
+.md-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  border: none;
+  border-radius: var(--radius-chip);
+  height: 44px;
+  padding: 0 20px;
+  cursor: pointer;
+  background: transparent;
+  color: var(--primary-color);
+  transition: background var(--transition-base), box-shadow var(--transition-base), transform var(--transition-base);
+  overflow: hidden;
+}
+
+.md-button .material-icons {
+  font-size: 20px;
+}
+
+.md-button:focus-visible {
+  outline: 2px solid rgba(103, 80, 164, 0.35);
+  outline-offset: 3px;
+}
+
+.md-button--filled {
+  background: var(--primary-color);
+  color: var(--on-primary-color);
+  box-shadow: var(--elevation-1);
+}
+
+.md-button--filled:hover {
+  box-shadow: var(--elevation-2);
+}
+
+.md-button--filled:active {
+  transform: translateY(1px);
+}
+
+.md-button--tonal {
+  background: var(--secondary-container);
+  color: var(--on-secondary-container);
+  box-shadow: var(--elevation-0);
+}
+
+.md-button--tonal:hover {
+  box-shadow: var(--elevation-1);
+}
+
+.md-button--outlined {
+  border: 1px solid var(--outline-color);
+  color: var(--primary-color);
+  background: transparent;
+}
+
+.md-button--outlined:hover {
+  background: rgba(103, 80, 164, 0.08);
+}
+
+.md-button--text {
+  height: auto;
+  padding: 8px 12px;
+  background: transparent;
+  color: var(--primary-color);
+}
+
+.md-button--text:hover {
+  background: rgba(103, 80, 164, 0.08);
+}
+
+.md-button--icon {
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  min-width: 44px;
+}
+
+.md-button--icon .material-icons {
+  font-size: 22px;
+}
+
+.md-button .ripple {
+  position: absolute;
+  border-radius: 50%;
+  transform: scale(0);
+  animation: ripple 600ms ease-out;
+  background: currentColor;
+  opacity: 0.18;
+  pointer-events: none;
+}
+
+.md-button--filled .ripple {
+  background: rgba(255, 255, 255, 0.35);
+}
+
+@keyframes ripple {
+  to {
+    transform: scale(8);
+    opacity: 0;
+  }
+}
+
+/* Chips */
+.chip-set {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-0-5);
+}
+
+.md-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  height: 40px;
+  padding: 0 18px;
+  border-radius: var(--radius-chip);
+  border: 1px solid rgba(103, 80, 164, 0.2);
+  background: transparent;
+  color: var(--primary-color);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background var(--transition-base), box-shadow var(--transition-base), border var(--transition-base);
+}
+
+.md-chip .material-icons {
+  font-size: 18px;
+}
+
+.md-chip.is-selected {
+  background: var(--secondary-container);
+  color: var(--on-secondary-container);
+  border-color: transparent;
+  box-shadow: var(--elevation-1);
+}
+
+.md-chip:focus-visible {
+  outline: 2px solid rgba(103, 80, 164, 0.35);
+  outline-offset: 2px;
+}
+
+/* Pattern cards */
+.pattern-grid {
+  display: grid;
+  gap: var(--spacing-1);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.pattern-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-0-5);
+  padding: var(--spacing-1);
+  border-radius: var(--radius-card);
+}
+
+.pattern-card__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(103, 80, 164, 0.12);
+  color: var(--primary-color);
+  font-size: 24px;
+}
+
+.pattern-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.meta-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: var(--radius-chip);
+  background: var(--surface-container-low);
+  color: var(--secondary-text);
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+/* Resources */
+.resource-grid {
+  display: grid;
+  gap: var(--spacing-1);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.resource-card {
+  background: rgba(255, 255, 255, 0.65);
+  backdrop-filter: blur(12px);
+  border-radius: 20px;
+  box-shadow: var(--elevation-1);
+  padding: var(--spacing-1);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-0-5);
+}
+
+.resource-card h3 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.resource-card p {
+  flex: 1;
+}
+
+/* Trend footnote */
+.trend-footnote {
+  margin-top: var(--spacing-2);
+}
+
+.trend-footnote__content {
+  display: grid;
+  gap: var(--spacing-0-75);
+  text-align: left;
+}
+
+@media only screen and (max-width: 768px) {
+  .section__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .hero {
+    padding: var(--spacing-1);
+  }
+
+  .hero__lead {
+    max-width: 60ch;
+  }
+
+  .hero__guides {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media only screen and (max-width: 568px) {
+  .md-card {
+    padding: var(--spacing-0-75);
+  }
+
+  .md-button {
+    height: 42px;
+    padding: 0 16px;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,202 +1,344 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
-<meta charset="utf-8">	
-<meta name="viewport" content="width=device-width, initial-scale=1" />  
-<title>Fast Demo Template</title> 	
-<!--
-<meta name="description" content=""> 
-<meta name="keywords" content=""> 	
-<link rel="shortcut icon" href="favicon.ico" /> 
--->	
-<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, user-scalable=yes" />
-<link rel="stylesheet" href="assets/global.css" />
-	
-	
-<!--https://materializecss.com/icons.html - Icon Font , ES EL MISMO QUE EL OFFICIAL, OSEA QUE GUT -->
-<!-- <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"> -->
-	
-<!-- http://google.github.io/material-design-icons/ - HAS INSTRUCTIONS FOR WHEN SELF HOSTING THE FONT -->	
-<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-	
-<!-- 
-HACER EL FAVICON ..... 
--->
-<!-- <link rel="shortcut icon" href="favicon.ico" /> -->	
-	
-<!--	
-DONE
-assets folder, with css, global, 
-
-PENDING
-img (empty for now, usin some pexels or whatver ... )			
-and the favicon folder stowed away, no favicon.ico in the root			
--->	
-	
-	<!--
-	BUT NO PHP YET, AS I WANT TO BE ABLE TO USE CTRL+E ... IF I CAN NOW ..? YES !!!!!!
-	-->
-	
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, user-scalable=yes" />
+  <title>Material UI Trend Demo</title>
+  <meta name="description" content="A Material Design inspired UI trend demo showcasing elevated surfaces, cards, and interaction patterns." />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="assets/global.css" />
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
 <div id="page">
-
-  
   <header>
     <div class="frame">
-			<div class="inner">
-				<div class="headerMain">FAST DEMO</div>
-				<div class="headerAside">Name of the demo</div>
-				
-        <div class="navicon">
-          <!-- FOR NAV -->
-          <span class="material-icons">menu</span>
-				</div>
-				
-			</div> <!-- /inner --> 
-    </div> <!-- /frame -->       
-  </header> 
-  
-  
-  
-  <div class="w_content">
+      <div class="inner">
+        <div class="brand">
+          <span class="brand__icon material-icons" aria-hidden="true">auto_awesome</span>
+          <div class="brand__copy">
+            <div class="headerMain">Material UI Trends</div>
+            <div class="headerAside">2024 Inspiration Deck</div>
+          </div>
+        </div>
+        <nav class="primary-nav" aria-label="Main navigation">
+          <ul>
+            <li><a href="#cards">Teams</a></li>
+            <li><a href="#patterns">Patterns</a></li>
+            <li><a href="#resources">Resources</a></li>
+          </ul>
+        </nav>
+        <button class="navicon md-button md-button--icon" type="button" aria-label="Open navigation" aria-expanded="false">
+          <span class="material-icons" aria-hidden="true">menu</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main class="w_content">
     <div class="frame">
-       
-			
+      <section class="surface hero surface--primary" aria-labelledby="hero-title">
+        <div class="hero__badge">Material You</div>
+        <h1 id="hero-title">Material design UI trend demo</h1>
+        <p class="hero__lead">Explore expressive surfaces, user cards, and interaction patterns inspired by the latest Material Design guidance.</p>
+        <div class="hero__actions">
+          <button class="md-button md-button--filled" type="button">
+            <span class="material-icons" aria-hidden="true">rocket_launch</span>
+            Explore components
+          </button>
+          <button class="md-button md-button--tonal" type="button">
+            <span class="material-icons" aria-hidden="true">download</span>
+            Download kit
+          </button>
+        </div>
+        <ul class="hero__guides">
+          <li>
+            <span class="material-icons" aria-hidden="true">layers</span>
+            Layered surfaces with adaptive elevation
+          </li>
+          <li>
+            <span class="material-icons" aria-hidden="true">color_lens</span>
+            Dynamic color applied to avatar gradients
+          </li>
+          <li>
+            <span class="material-icons" aria-hidden="true">motion_photos_on</span>
+            Motion-ready components &amp; micro interactions
+          </li>
+        </ul>
+      </section>
 
-			
-			
-			<!--
-      Your code goes here...<br>
-			-->
-			
-			
-<!--
-			ANTES DE SALTAR AL 4, 5 - HACER LO DE LOS MATETRIAL ICONS 
--->      
-	
-<!--			
-			<br>	
-			
-			<br>
-<br>
-<br>
-mATERIAL ICONS - https://material.io/resources/icons/?style=baseline
-		<br>
-			(esto ya soporta tbsu propio icon font, usage en el lateral,learn to do the call...
-			
-			)
-			<br>
-<br>
+      <section class="chip-tray surface surface--raised" aria-labelledby="chip-title">
+        <h2 id="chip-title" class="visually-hidden">Focus areas</h2>
+        <div class="chip-set" role="list">
+          <button class="md-chip is-selected" type="button" role="listitem" aria-pressed="true">
+            <span class="material-icons" aria-hidden="true">explore</span>
+            Adaptive layouts
+          </button>
+          <button class="md-chip" type="button" role="listitem" aria-pressed="false">
+            <span class="material-icons" aria-hidden="true">animation</span>
+            Expressive motion
+          </button>
+          <button class="md-chip" type="button" role="listitem" aria-pressed="false">
+            <span class="material-icons" aria-hidden="true">gradient</span>
+            Color systems
+          </button>
+          <button class="md-chip" type="button" role="listitem" aria-pressed="false">
+            <span class="material-icons" aria-hidden="true">hearing</span>
+            Accessibility
+          </button>
+          <button class="md-chip" type="button" role="listitem" aria-pressed="false">
+            <span class="material-icons" aria-hidden="true">touch_app</span>
+            Micro-interactions
+          </button>
+        </div>
+      </section>
 
-			
-			
-			
-AND SEEK MATERIAL ICON FONT 			
-			
-	<br>			
-			
+      <section class="section" id="cards" aria-labelledby="cards-title">
+        <header class="section__header">
+          <div>
+            <h2 id="cards-title">Featured product teams</h2>
+            <p class="section__subtitle">User cards demonstrating elevated surfaces, typography hierarchy, and supportive color systems.</p>
+          </div>
+          <button class="md-button md-button--outlined" type="button">
+            <span class="material-icons" aria-hidden="true">add</span>
+            Add card
+          </button>
+        </header>
+        <div class="card-grid">
+          <article class="md-card">
+            <div class="md-card__header">
+              <div class="md-card__avatar avatar avatar--sunrise" aria-hidden="true">AJ</div>
+              <div class="md-card__titles">
+                <h3>Amelia Jones</h3>
+                <p class="md-card__subtitle">Lead Product Designer · Quartz</p>
+              </div>
+              <button class="md-button md-button--icon" type="button" aria-label="More options for Amelia Jones">
+                <span class="material-icons" aria-hidden="true">more_vert</span>
+              </button>
+            </div>
+            <div class="md-card__body">
+              <p>Crafts inclusive design systems that balance dynamic color with high legibility across adaptive layouts.</p>
+              <ul class="md-list">
+                <li>
+                  <span class="material-icons" aria-hidden="true">palette</span>
+                  Tonal palettes mapped to dynamic color tokens
+                </li>
+                <li>
+                  <span class="material-icons" aria-hidden="true">grid_view</span>
+                  Grid-based responsive scaffolds at 4dp increments
+                </li>
+                <li>
+                  <span class="material-icons" aria-hidden="true">tips_and_updates</span>
+                  Prototype-first approach with motion handoffs
+                </li>
+              </ul>
+            </div>
+            <div class="md-card__footer">
+              <button class="md-button md-button--text" type="button">View playbook</button>
+              <button class="md-button md-button--text" type="button">Share</button>
+            </div>
+          </article>
 
-			
-<i class="material-icons">add</i>
-<i class="large material-icons">add</i>
-<i class="large material-icons">insert_chart</i>
-<i class="material-icons">accessibility</i>		
-			
-			
-<br>
-<br>
-<br>
-<br>
+          <article class="md-card">
+            <div class="md-card__header">
+              <div class="md-card__avatar avatar avatar--lagoon" aria-hidden="true">KM</div>
+              <div class="md-card__titles">
+                <h3>Keon Malik</h3>
+                <p class="md-card__subtitle">Design Technologist · Nebula Labs</p>
+              </div>
+              <button class="md-button md-button--icon" type="button" aria-label="More options for Keon Malik">
+                <span class="material-icons" aria-hidden="true">more_vert</span>
+              </button>
+            </div>
+            <div class="md-card__body">
+              <p>Connects prototyping and production by building robust Material 3 component libraries.</p>
+              <ul class="md-list">
+                <li>
+                  <span class="material-icons" aria-hidden="true">layers_clear</span>
+                  Elevation tokens for restful and express states
+                </li>
+                <li>
+                  <span class="material-icons" aria-hidden="true">bolt</span>
+                  Motion specs synced with Android Compose
+                </li>
+                <li>
+                  <span class="material-icons" aria-hidden="true">code</span>
+                  Token-driven theming published to design ops
+                </li>
+              </ul>
+            </div>
+            <div class="md-card__footer">
+              <button class="md-button md-button--text" type="button">View prototype</button>
+              <button class="md-button md-button--text" type="button">Connect</button>
+            </div>
+          </article>
 
-<span class="material-icons">accessibility</span>	
+          <article class="md-card">
+            <div class="md-card__header">
+              <div class="md-card__avatar avatar avatar--dusk" aria-hidden="true">LS</div>
+              <div class="md-card__titles">
+                <h3>Linh Seo</h3>
+                <p class="md-card__subtitle">Research Lead · Haptic Studio</p>
+              </div>
+              <button class="md-button md-button--icon" type="button" aria-label="More options for Linh Seo">
+                <span class="material-icons" aria-hidden="true">more_vert</span>
+              </button>
+            </div>
+            <div class="md-card__body">
+              <p>Advocates for accessibility-forward journeys paired with gentle, high-contrast tonal ramps.</p>
+              <ul class="md-list">
+                <li>
+                  <span class="material-icons" aria-hidden="true">hearing</span>
+                  Focus states and motion alternatives for inclusivity
+                </li>
+                <li>
+                  <span class="material-icons" aria-hidden="true">insights</span>
+                  Research sprints evaluating adaptive surfaces
+                </li>
+                <li>
+                  <span class="material-icons" aria-hidden="true">emoji_objects</span>
+                  Insight decks shared via collaborative crits
+                </li>
+              </ul>
+            </div>
+            <div class="md-card__footer">
+              <button class="md-button md-button--text" type="button">View insights</button>
+              <button class="md-button md-button--text" type="button">Invite</button>
+            </div>
+          </article>
 
--->			
-			
+          <article class="md-card">
+            <div class="md-card__header">
+              <div class="md-card__avatar avatar avatar--citrus" aria-hidden="true">TR</div>
+              <div class="md-card__titles">
+                <h3>Tamara Ruiz</h3>
+                <p class="md-card__subtitle">Design Ops · Lumen Collective</p>
+              </div>
+              <button class="md-button md-button--icon" type="button" aria-label="More options for Tamara Ruiz">
+                <span class="material-icons" aria-hidden="true">more_vert</span>
+              </button>
+            </div>
+            <div class="md-card__body">
+              <p>Aligns product squads with shared Material guidelines, ensuring components scale with clarity.</p>
+              <ul class="md-list">
+                <li>
+                  <span class="material-icons" aria-hidden="true">dashboard_customize</span>
+                  Unified design tokens for multi-platform releases
+                </li>
+                <li>
+                  <span class="material-icons" aria-hidden="true">sync_alt</span>
+                  Rituals aligning weekly pattern audits
+                </li>
+                <li>
+                  <span class="material-icons" aria-hidden="true">emoji_events</span>
+                  Success metrics tied to usability benchmarks
+                </li>
+              </ul>
+            </div>
+            <div class="md-card__footer">
+              <button class="md-button md-button--text" type="button">View roadmap</button>
+              <button class="md-button md-button--text" type="button">Message</button>
+            </div>
+          </article>
+        </div>
+      </section>
 
-			
+      <section class="section" id="patterns" aria-labelledby="patterns-title">
+        <header class="section__header">
+          <div>
+            <h2 id="patterns-title">Interaction patterns</h2>
+            <p class="section__subtitle">Patterns translate Material Design foundations into ready-to-use experiences.</p>
+          </div>
+        </header>
+        <div class="pattern-grid">
+          <article class="pattern-card surface surface--raised">
+            <span class="pattern-card__icon material-icons" aria-hidden="true">view_carousel</span>
+            <h3>Layered cards</h3>
+            <p>Stagger elevation (1dp → 3dp) to guide focus while preserving consistent 24dp corner radii.</p>
+            <div class="pattern-card__meta">
+              <span class="meta-badge">Elevation 3dp</span>
+              <span class="meta-badge">Spacing 16dp</span>
+            </div>
+          </article>
 
-			
-			
+          <article class="pattern-card surface surface--raised">
+            <span class="pattern-card__icon material-icons" aria-hidden="true">view_day</span>
+            <h3>Split layouts</h3>
+            <p>Combine supportive tonal blocks with high-contrast typography for quick-scanning dashboards.</p>
+            <div class="pattern-card__meta">
+              <span class="meta-badge">Grid 12 col</span>
+              <span class="meta-badge">Breakpoint 768px</span>
+            </div>
+          </article>
 
-			
-			
-			
-			
+          <article class="pattern-card surface surface--raised">
+            <span class="pattern-card__icon material-icons" aria-hidden="true">timeline</span>
+            <h3>Motion handoffs</h3>
+            <p>Tokenize easing &amp; duration values so prototyping and development speak the same language.</p>
+            <div class="pattern-card__meta">
+              <span class="meta-badge">Ease 0.2/0</span>
+              <span class="meta-badge">Duration 250ms</span>
+            </div>
+          </article>
+        </div>
+      </section>
 
-			
-			<div class="m_htmleditor">
-				<!-- start slipsum code -->
+      <section class="section surface surface--primary" id="resources" aria-labelledby="resources-title">
+        <div class="section__header">
+          <div>
+            <h2 id="resources-title">Resources &amp; guidelines</h2>
+            <p class="section__subtitle">Accelerate your next sprint with curated Material Design references.</p>
+          </div>
+        </div>
+        <div class="resource-grid">
+          <article class="resource-card">
+            <h3>Component specs</h3>
+            <p>Download ready-to-build specs with density guidance, state tables, and accessibility notes.</p>
+            <button class="md-button md-button--text" type="button">Open library</button>
+          </article>
+          <article class="resource-card">
+            <h3>Motion blueprints</h3>
+            <p>Link micro-interactions to component states for prototypes that translate seamlessly to code.</p>
+            <button class="md-button md-button--text" type="button">View timeline</button>
+          </article>
+          <article class="resource-card">
+            <h3>Color foundations</h3>
+            <p>Mix tonal palettes and extract tokens that respond to wallpaper-driven dynamic color.</p>
+            <button class="md-button md-button--text" type="button">Generate palette</button>
+          </article>
+        </div>
+      </section>
 
-				<h1>I gotta piss</h1>
-				<p>The path of the righteous man is beset on all sides by the iniquities of the selfish and the tyranny of evil men. Blessed is he who, in the name of charity and good will, shepherds the weak through the valley of darkness, for he is truly his brother's keeper and the finder of lost children. And I will strike down upon thee with great vengeance and furious anger those who would attempt to poison and destroy My brothers. And you will know My name is the Lord when I lay My vengeance upon thee.</p>
-				<p>Now that there is the Tec-9, a crappy spray gun from South Miami. This gun is advertised as the most popular gun in American crime. Do you believe that shit? It actually says that in the little book that comes with it: the most popular gun in American crime. Like they're actually proud of that shit.</p>
-				
-				<h2>I can do that</h2>
-				<p>The path of the righteous man is beset on all sides by the iniquities of the selfish and the tyranny of evil men. Blessed is he who, in the name of charity and good will, shepherds the weak through the valley of darkness, for he is truly his brother's keeper and the finder of lost children. And I will strike down upon thee with great vengeance and furious anger those who would attempt to poison and destroy My brothers. And you will know My name is the Lord when I lay My vengeance upon thee.</p>				
-				<p>Now that there is the Tec-9, a crappy spray gun from South Miami. This gun is advertised as the most popular gun in American crime. Do you believe that shit? It actually says that in the little book that comes with it: the most popular gun in American crime. Like they're actually proud of that shit.</p>
-				
-				<h3>I can do that</h3>
-				<p>The path of the righteous man is beset on all sides by the iniquities of the selfish and the tyranny of evil men. Blessed is he who, in the name of charity and good will, shepherds the weak through the valley of darkness, for he is truly his brother's keeper and the finder of lost children. And I will strike down upon thee with great vengeance and furious anger those who would attempt to poison and destroy My brothers. And you will know My name is the Lord when I lay My vengeance upon thee.</p>				
-				<p>Now that there is the Tec-9, a crappy spray gun from South Miami. This gun is advertised as the most popular gun in American crime. Do you believe that shit? It actually says that in the little book that comes with it: the most popular gun in American crime. Like they're actually proud of that shit.</p>				
-				
-				<h4>I can do that</h4>
-				<p>The path of the righteous man is beset on all sides by the iniquities of the selfish and the tyranny of evil men. Blessed is he who, in the name of charity and good will, shepherds the weak through the valley of darkness, for he is truly his brother's keeper and the finder of lost children. And I will strike down upon thee with great vengeance and furious anger those who would attempt to poison and destroy My brothers. And you will know My name is the Lord when I lay My vengeance upon thee.</p>				
-				<p>Now that there is the Tec-9, a crappy spray gun from South Miami. This gun is advertised as the most popular gun in American crime. Do you believe that shit? It actually says that in the little book that comes with it: the most popular gun in American crime. Like they're actually proud of that shit.</p>
-				
-				<h5>I can do that</h5>
-				<p>The path of the righteous man is beset on all sides by the iniquities of the selfish and the tyranny of evil men. Blessed is he who, in the name of charity and good will, shepherds the weak through the valley of darkness, for he is truly his brother's keeper and the finder of lost children. And I will strike down upon thee with great vengeance and furious anger those who would attempt to poison and destroy My brothers. And you will know My name is the Lord when I lay My vengeance upon thee.</p>				
-				<p>Now that there is the Tec-9, a crappy spray gun from South Miami. This gun is advertised as the most popular gun in American crime. Do you believe that shit? It actually says that in the little book that comes with it: the most popular gun in American crime. Like they're actually proud of that shit.</p>
-				
-				<h6>I can do that</h6>
-				<p>The path of the righteous man is beset on all sides by the iniquities of the selfish and the tyranny of evil men. Blessed is he who, in the name of charity and good will, shepherds the weak through the valley of darkness, for he is truly his brother's keeper and the finder of lost children. And I will strike down upon thee with great vengeance and furious anger those who would attempt to poison and destroy My brothers. And you will know My name is the Lord when I lay My vengeance upon thee.</p>				
-				<p>Now that there is the Tec-9, a crappy spray gun from South Miami. This gun is advertised as the most popular gun in American crime. Do you believe that shit? It actually says that in the little book that comes with it: the most popular gun in American crime. Like they're actually proud of that shit.</p>
-				
-				<!-- end slipsum code -->
+      <section class="section trend-footnote">
+        <div class="surface surface--raised trend-footnote__content">
+          <h2>Design the future, one surface at a time</h2>
+          <p>Every component here celebrates Material Design&#8217;s evolving language&mdash;blend color, motion, and accessible structure to ship experiences users love.</p>
+          <div class="hero__actions">
+            <button class="md-button md-button--filled" type="button">
+              <span class="material-icons" aria-hidden="true">auto_awesome</span>
+              Start prototyping
+            </button>
+            <button class="md-button md-button--outlined" type="button">
+              <span class="material-icons" aria-hidden="true">groups</span>
+              Join the community
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  </main>
 
-				<!--
-				<button>Click me (reset the button behavior firts .. </button>
-				
-			<br>
-			<br>
-				-->
-				
-			<button class="text-button">Text Button</button>
-			<button class="outlined-button">Outlined button</button>
-			<button class="contained-button-with-icon">
-				<span class="material-icons">add</span>
-				Button
-			</button>
-			<button class="contained-button">Button</button>
-				
-			
-				
-			</div> <!-- /m_htmleditor -->	
-			
-			
-			
-    </div> <!-- /frame --> 
-  </div> <!-- /w_content -->
-  
-  
-  <footer class="stickyFooter"> <!--OJO QUE TIENE CONSECUENCIAS EN LAYOUT TESTINGS-->	
+  <footer class="stickyFooter">
     <div class="frame">
       <div class="inner">
-				
-				
-          <div>by Carl Johansson </div> 
-				
-					<!-- FOR SCOL TO TOP -->
-					<span class="material-icons">arrow_upward</span>
-				
-				
-				
-      </div>       
-    </div> <!-- /frame -->          
-  </footer>   
-
-</div> <!-- /page -->
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+        <div>Built as a Material Design trend showcase.</div>
+        <a href="https://material.io/design" target="_blank" rel="noreferrer" class="footer-link">Review the guidelines</a>
+      </div>
+    </div>
+  </footer>
+</div>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
 <script src="js/scripts.js"></script>
 </body>
 </html>

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -1,14 +1,43 @@
-/* 
- * jQuery
- * global.js // SCRIPTS.JS ES COMO DECIR STYLE.CSS, PEOR USO GLOBAL.CSS ... 
+/*
+ * Interaction enhancements for the Material UI demo
  */
 
-/*$(document).ready(function(){
-  $("#demo_wrapper_1").click(function(){
-    $("#demo_wrapper_2").slideToggle("slow");
-  });
-})*/
+$(function () {
+  // Ripple effect for buttons
+  $(document).on('click', '.md-button', function (event) {
+    const $button = $(this);
+    const offset = $button.offset();
+    const diameter = Math.max($button.outerWidth(), $button.outerHeight());
+    const x = event.pageX - offset.left - diameter / 2;
+    const y = event.pageY - offset.top - diameter / 2;
 
-$("header").click(function() {
-		// $(this).hide('slow');
+    const $ripple = $('<span class="ripple" />').css({
+      width: diameter,
+      height: diameter,
+      left: x,
+      top: y
+    });
+
+    $button.find('.ripple').remove();
+    $button.append($ripple);
+  });
+
+  // Toggle stateful filter chips
+  $(document).on('click', '.md-chip', function () {
+    const $chip = $(this);
+    const isSelected = !$chip.hasClass('is-selected');
+    $chip.toggleClass('is-selected', isSelected);
+    $chip.attr('aria-pressed', isSelected.toString());
+  });
+
+  // Mobile navigation toggle
+  $('.navicon').on('click', function () {
+    const $nav = $('.primary-nav');
+    const willOpen = !$nav.hasClass('is-open');
+    $nav.toggleClass('is-open', willOpen);
+    $(this)
+      .attr('aria-expanded', willOpen.toString())
+      .attr('aria-label', willOpen ? 'Close navigation' : 'Open navigation');
+    $(this).find('.material-icons').text(willOpen ? 'close' : 'menu');
+  });
 });


### PR DESCRIPTION
## Summary
- Rebuild the landing page as a Material Design trend demo with hero, chips, cards, pattern highlights, resources, and CTA sections
- Refresh the global style tokens, layout, and component styling around Material 3 colors, elevations, and responsive spacing
- Add interactive enhancements including button ripples, filter chip toggles, and a collapsible mobile navigation trigger

## Testing
- python3 -m http.server 8000 (manual preview)


------
https://chatgpt.com/codex/tasks/task_e_68cda6d7650c83269f3306e4fc039fb1