### PR TITLE
Add pattern reference table and FAQ dropdowns

### DIFF
--- a/assets/css/5-content.css
+++ b/assets/css/5-content.css
@@ -354,6 +354,55 @@
   border-radius: var(--radius-card);
 }
 
+.pattern-table-wrap {
+  overflow-x: auto;
+}
+
+.pattern-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 560px;
+  background: var(--surface-container);
+  border-radius: var(--radius-card);
+  box-shadow: var(--elevation-1);
+  overflow: hidden;
+}
+
+.pattern-table caption {
+  text-align: left;
+  font-weight: 600;
+  padding: var(--spacing-0-75);
+  background: var(--surface-container-highest);
+}
+
+.pattern-table th,
+.pattern-table td {
+  padding: 14px 16px;
+  text-align: left;
+  border-bottom: 1px solid rgba(103, 80, 164, 0.1);
+}
+
+.pattern-table thead th {
+  font-size: 0.95rem;
+  color: var(--secondary-text);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.pattern-table tbody tr:last-child th,
+.pattern-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.pattern-table tbody th {
+  font-weight: 600;
+  color: var(--on-surface);
+}
+
+.pattern-table tbody td {
+  color: var(--secondary-text);
+}
+
 .pattern-card__icon {
   width: 48px;
   height: 48px;
@@ -381,6 +430,52 @@
   color: var(--secondary-text);
   font-size: 0.85rem;
   font-weight: 500;
+}
+
+.faq-list {
+  display: grid;
+  gap: var(--spacing-0-75);
+}
+
+.faq-item {
+  background: var(--surface-container);
+  border-radius: var(--radius-card);
+  box-shadow: var(--elevation-1);
+  padding: var(--spacing-0-75);
+}
+
+.faq-item[open] {
+  box-shadow: var(--elevation-2);
+}
+
+.faq-item summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  font-weight: 600;
+  list-style: none;
+}
+
+.faq-item summary::-webkit-details-marker {
+  display: none;
+}
+
+.faq-item summary::after {
+  content: "expand_more";
+  font-family: "Material Icons";
+  font-size: 20px;
+  transition: transform var(--transition-base);
+  color: var(--primary-color);
+}
+
+.faq-item[open] summary::after {
+  transform: rotate(180deg);
+}
+
+.faq-item p {
+  margin: 12px 0 0;
+  color: var(--secondary-text);
 }
 
 /* Resources */

--- a/index.html
+++ b/index.html
@@ -282,6 +282,58 @@
             </div>
           </article>
         </div>
+        <div class="pattern-table-wrap">
+          <table class="pattern-table">
+            <caption>Pattern quick reference</caption>
+            <thead>
+              <tr>
+                <th scope="col">Pattern</th>
+                <th scope="col">Best for</th>
+                <th scope="col">Key tokens</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">Layered cards</th>
+                <td>Highlighting prioritized content within dashboards</td>
+                <td>Elevation 1dp–3dp, corner radius 24dp</td>
+              </tr>
+              <tr>
+                <th scope="row">Split layouts</th>
+                <td>Responsive layouts that balance navigation and content</td>
+                <td>12-column grid, breakpoint 768px</td>
+              </tr>
+              <tr>
+                <th scope="row">Motion handoffs</th>
+                <td>Design-to-dev collaboration on interactive flows</td>
+                <td>Easing 0.2/0, duration 250ms</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="section" id="faqs" aria-labelledby="faqs-title">
+        <header class="section__header">
+          <div>
+            <h2 id="faqs-title">FAQs</h2>
+            <p class="section__subtitle">Get quick answers about using and adapting this Material Design demo.</p>
+          </div>
+        </header>
+        <div class="faq-list">
+          <details class="faq-item">
+            <summary>How can I adapt the demo to match my brand?</summary>
+            <p>Update the color tokens in the variables file and adjust the gradient accents to match your palette while keeping contrast ratios accessible.</p>
+          </details>
+          <details class="faq-item">
+            <summary>Can I use these components in production?</summary>
+            <p>Yes&mdash;the layout and tokens follow Material 3 guidance, so you can port them into your design system or front-end framework of choice.</p>
+          </details>
+          <details class="faq-item">
+            <summary>Where do I find more Material Design resources?</summary>
+            <p>Visit the resources section below for direct links to specs, motion blueprints, and color tooling curated for fast exploration.</p>
+          </details>
+        </div>
       </section>
 
       <section class="section surface surface--primary" id="resources" aria-labelledby="resources-title">


### PR DESCRIPTION
## Summary
- add a reference table summarizing the featured interaction patterns
- introduce an FAQ section that uses Material-inspired details/summary dropdowns
- style the new table and FAQ components to match the existing system

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdbbedbd348326a7b7614ed92a2d0f